### PR TITLE
Use Rwlock instead of Mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "sider"
-version = "0.1.1"
+version = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sider"
 description = "A Multithreaded Redis clone written from scratch in Rust."
 license = "MIT"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -46,31 +46,15 @@ On my machine which has an i5-9300H Intel CPU.
 ```
 redis-benchmark -n 100000 -c 100 -t set,get
 
-SET: 42844.90 requests per second
-GET: 43840.42 requests per second
+SET: 79365.08 requests per second
+GET: 82034.45 requests per second
 ```
 
 ```
 redis-benchmark -n 500000 -c 1000 -t set,get
 
-SET: 40041.64 requests per second
-GET: 40650.41 requests per second
-```
-
-In comparsion to Redis (also on my machine):
-
-```
-redis-benchmark -n 100000 -c 100 -t set,get
-
-SET: 34246.57 requests per second
-GET: 34364.26 requests per second
-```
-
-```
-redis-benchmark -n 500000 -c 1000 -t set,get
-
-SET: 31527.84 requests per second
-GET: 32032.80 requests per second
+SET: 56433.41 requests per second
+GET: 57077.62 requests per second
 ```
 
 Performance may vary depending on the machine you run the benchmarks on.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     net::TcpListener,
-    sync::{Arc, Mutex},
+    sync::{Arc, RwLock},
     thread,
     time::Duration,
 };
@@ -27,7 +27,7 @@ impl Sider {
 
     pub fn start(&self) {
         println!("Sider is running on port {}", self.port);
-        let mut cache = Arc::new(Mutex::new(HashMap::new()));
+        let mut cache = Arc::new(RwLock::new(HashMap::new()));
         let timeout = self.timeout;
         for stream in self.listener.incoming() {
             let cache = Arc::clone(&mut cache);


### PR DESCRIPTION
Use RwLock instead of Mutex
https://doc.rust-lang.org/stable/std/sync/struct.RwLock.html

The performance in this case depends on the OS implementation.

I found RwLock to be slower sometimes, but I think overall it slightly edges the performance of a Mutex.

Another comparison: https://fy.blackhats.net.au/blog/html/2018/10/19/rust_rwlock_and_mutex_performance_oddities.html